### PR TITLE
Upstream Actualizado (Waterfall)

### DIFF
--- a/advocatus
+++ b/advocatus
@@ -7,7 +7,7 @@ case "$1" in
     "p" | "patch")
         scripts/build.sh
     ;;
-    "u" | "f" | "fetch")
+    "c" | "uc" | "commit")
         scripts/upstreamCommit.sh
     ;;
     "m" | "up" | "merge")
@@ -30,6 +30,7 @@ case "$1" in
         echo "  * rb, rbp, rebuild | Rebuilds the patches"
         echo "  * p, patch         | Applies all the patches to BungeeCord"
         echo "  * m, up, merge     | Utility to aid in merging upstream"
+	echo "  * c, uc, commit    | Utility to commit upstream changes"
         echo "  * b, build         | Builds the project"
         echo "                     | The bootstrap artifact can be found in Advocatus-Proxy/bootstrap/target/"
         echo "  * e, edit          | Runs git rebase -i for Waterfall, allowing patches to be easily modified"

--- a/scripts/upstreamCommit.sh
+++ b/scripts/upstreamCommit.sh
@@ -12,7 +12,7 @@ advocatus=$(changelog Waterfall)
 updated=""
 logsuffix=""
 if [ ! -z "$advocatus" ]; then
-    logsuffix="$logsuffix\n\nAdvocatus Changes:\n$advocatus"
+    logsuffix="$logsuffix\n\nCambios de Waterfall:\n$advocatus"
     if [ -z "$updated" ]; then updated="Waterfall"; else updated="$updated/Waterfall"; fi
 fi
 disclaimer="Upstream ha publicado actualizaciones que parecen aplicarse y compilarse correctamente. \nEsta actualización no ha sido probada por PaperMC o RoyalMind y, como con CUALQUIER actualización, haga sus propias pruebas."
@@ -21,7 +21,7 @@ if [ ! -z "$1" ]; then
     disclaimer="$@"
 fi
 
-log="${UP_LOG_PREFIX}Actualizado Upstream ($updated)\n\n${disclaimer}${logsuffix}"
+log="${UP_LOG_PREFIX}Upstream Actualizado ($updated)\n\n${disclaimer}${logsuffix}"
 
 echo -e "$log" | git commit -F -
 


### PR DESCRIPTION
Upstream ha publicado actualizaciones que parecen aplicarse y compilarse correctamente.
Esta actualización no ha sido probada por PaperMC o RoyalMind y, como con CUALQUIER actualización, haga sus propias pruebas.

Cambios de Waterfall:
2e8afd0 Update to log4j snapshot
f45703f Backport log4j fix from 2.15.0